### PR TITLE
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format

### DIFF
--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/pipelines/templates/jobs/docindex.yml
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/pipelines/templates/jobs/docindex.yml
@@ -1,7 +1,8 @@
 jobs:
   - job: CreateDocIndex
     pool:
-      vmImage: windows-2019
+      name: azsdk-pool-mms-win-2022-general
+      vmImage: windows-2022
     steps:
       - task: UsePythonVersion@0
         displayName: 'Use Python 3.6'
@@ -19,7 +20,7 @@ jobs:
         displayName: 'Generate Doc Index'
         inputs:
           pwsh: true
-          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1 
+          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1
           arguments: >
             -Docfx $(docfxPath)
             -RepoRoot $(Build.SourcesDirectory)
@@ -38,14 +39,14 @@ jobs:
           Copy-Item -Path $(Build.SourcesDirectory)/eng/* -Destination ./ -Recurse -Force
           echo "##vso[task.setvariable variable=toolPath]$(Build.BinariesDirectory)"
         workingDirectory: $(Build.BinariesDirectory)
-        displayName: Move eng/common to Tool Directory   
+        displayName: Move eng/common to Tool Directory
 
       - task: PublishPipelineArtifact@0
         condition: succeeded()
         inputs:
           artifactName: "Doc.Index"
           targetPath: $(Build.ArtifactStagingDirectory)/docfx_project/_site
-          
+
       - pwsh: |
           git checkout -b gh-pages-local --track origin/gh-pages-root -f
         workingDirectory: $(Build.SourcesDirectory)

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/pipelines/templates/steps/docindex.yml
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/pipelines/templates/steps/docindex.yml
@@ -1,7 +1,8 @@
 jobs:
   - job: CreateDocIndex
     pool:
-      vmImage: windows-2019
+      name: azsdk-pool-mms-win-2022-general
+      vmImage: windows-2022
     steps:
       - task: UsePythonVersion@0
         displayName: 'Use Python 3.6'
@@ -19,7 +20,7 @@ jobs:
         displayName: 'Generate Doc Index'
         inputs:
           pwsh: true
-          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1 
+          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1
           arguments: >
             -Docfx $(docfxPath)
             -RepoRoot $(Build.SourcesDirectory)
@@ -38,14 +39,14 @@ jobs:
           Copy-Item -Path $(Build.SourcesDirectory)/eng/* -Destination ./ -Recurse -Force
           echo "##vso[task.setvariable variable=toolPath]$(Build.BinariesDirectory)"
         workingDirectory: $(Build.BinariesDirectory)
-        displayName: Move eng/common to Tool Directory   
+        displayName: Move eng/common to Tool Directory
 
       - task: PublishPipelineArtifact@0
         condition: succeeded()
         inputs:
           artifactName: "Doc.Index"
           targetPath: $(Build.ArtifactStagingDirectory)/docfx_project/_site
-          
+
       - pwsh: |
           git checkout -b gh-pages-local --track origin/gh-pages-root -f
         workingDirectory: $(Build.SourcesDirectory)

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/Verify-AgentOS.ps1
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/Verify-AgentOS.ps1
@@ -8,7 +8,7 @@ function Throw-InvalidOperatingSystem {
     throw "Invalid operating system detected. Operating system was: $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription), expected image was: $AgentImage"
 }
 
-if ($IsWindows -and $AgentImage -match "windows|win|MMS2019") {
+if ($IsWindows -and $AgentImage -match "windows|win|windows-2022") {
     $osName = "Windows"
 } elseif ($IsLinux -and $AgentImage -match "ubuntu") {
     $osName = "Linux"

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/README.md
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/README.md
@@ -100,7 +100,7 @@ Example:
 ```
 "matrix": {
   "operatingSystem": [
-    "windows-2019",
+    "windows-2022",
     "ubuntu-18.04",
     "macOS-10.15"
   ],
@@ -386,14 +386,14 @@ In the matrix job output that azure pipelines consumes, the format is a dictiona
     "framework": "net50",
     "operatingSystem": "ubuntu-18.04"
   },
-  "netcoreapp21_windows2019": {
+  "netcoreapp21_windows2022": {
     "framework": "netcoreapp2.1",
-    "operatingSystem": "windows-2019"
+    "operatingSystem": "windows-2022"
   },
-  "UseProjectRef_net461_windows2019": {
+  "UseProjectRef_net461_windows2022": {
     "additionalTestArguments": "/p:UseProjectReferenceToAzureClients=true",
     "framework": "net461",
-    "operatingSystem": "windows-2019"
+    "operatingSystem": "windows-2022"
   }
 }
 ```
@@ -510,7 +510,7 @@ Given a matrix like below with `JavaTestVersion` marked as a non-sparse paramete
 {
   "matrix": {
     "Agent": {
-      "windows-2019": { "OSVmImage": "MMS2019", "Pool": "azsdk-pool-mms-win-2019-general" },
+      "windows-2022": { "OSVmImage": "windows-2022", "Pool": "azsdk-pool-mms-win-2022-general" },
       "ubuntu-1804": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" },
       "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/samples/matrix.json
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/samples/matrix.json
@@ -5,7 +5,7 @@
   "matrix": {
     "Agent": {
       "ubuntu": { "OSVmImage": "ubuntu-18.04", "Pool": "Azure Pipelines" },
-      "windows": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" },
+      "windows": { "OSVmImage": "windows-2022", "Pool": "Azure Pipelines" },
       "macOS": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },
     "TestTargetFramework": [ "netcoreapp2.1", "net461", "net5.0" ]
@@ -13,7 +13,7 @@
   "include": [
     {
       "Agent": {
-        "windows": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" }
+        "windows": { "OSVmImage": "windows-2022", "Pool": "Azure Pipelines" }
       },
       "TestTargetFramework": [ "net461", "net5.0" ],
       "AdditionalTestArguments": "/p:UseProjectReferenceToAzureClients=true"
@@ -21,7 +21,7 @@
   ],
   "exclude": [
     {
-      "OSVmImage": "MMS2019",
+      "OSVmImage": "windows-2022",
       "framework": "netcoreapp2.1"
     }
   ]

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.filter.tests.ps1
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.filter.tests.ps1
@@ -6,7 +6,7 @@ BeforeAll {
     $matrixConfig = @"
 {
     "matrix": {
-        "operatingSystem": [ "windows-2019", "ubuntu-18.04", "macOS-10.15" ],
+        "operatingSystem": [ "windows-2022", "ubuntu-18.04", "macOS-10.15" ],
         "framework": [ "net461", "netcoreapp2.1" ],
         "additionalArguments": [ "", "mode=test" ]
     }
@@ -17,8 +17,8 @@ BeforeAll {
 
 Describe "Matrix Filter" -Tag "filter" {
     It "Should filter by matrix display name" -TestCases @(
-        @{ regex = "windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ regex = "windows2019_netcoreapp21_modetest"; expectedFirst = "windows2019_netcoreapp21_modetest"; length = 1 }
+        @{ regex = "windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ regex = "windows2022_netcoreapp21_modetest"; expectedFirst = "windows2022_netcoreapp21_modetest"; length = 1 }
         @{ regex = ".*ubuntu.*"; expectedFirst = "ubuntu1804_net461"; length = 4 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" $regex
@@ -33,11 +33,11 @@ Describe "Matrix Filter" -Tag "filter" {
     }
 
     It "Should filter by matrix key/value" -TestCases @(
-        @{ filterString = "operatingSystem=windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "operatingSystem=windows-2019"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "framework=.*"; expectedFirst = "windows2019_net461"; length = 12 }
-        @{ filterString = "additionalArguments=mode=test"; expectedFirst = "windows2019_net461_modetest"; length = 6 }
-        @{ filterString = "additionalArguments=^$"; expectedFirst = "windows2019_net461"; length = 6 }
+        @{ filterString = "operatingSystem=windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "operatingSystem=windows-2022"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "framework=.*"; expectedFirst = "windows2022_net461"; length = 12 }
+        @{ filterString = "additionalArguments=mode=test"; expectedFirst = "windows2022_net461_modetest"; length = 6 }
+        @{ filterString = "additionalArguments=^$"; expectedFirst = "windows2022_net461"; length = 6 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" -filters @($filterString)
         $matrix.Length | Should -Be $length
@@ -45,8 +45,8 @@ Describe "Matrix Filter" -Tag "filter" {
     }
 
     It "Should filter by optional matrix key/value" -TestCases @(
-        @{ filterString = "operatingSystem=^$|windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "doesnotexist=^$|.*"; expectedFirst = "windows2019_net461"; length = 12 }
+        @{ filterString = "operatingSystem=^$|windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "doesnotexist=^$|.*"; expectedFirst = "windows2022_net461"; length = 12 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" -filters @($filterString)
         $matrix.Length | Should -Be $length
@@ -56,7 +56,7 @@ Describe "Matrix Filter" -Tag "filter" {
     It "Should handle multiple matrix key/value filters " {
         [array]$matrix = GenerateMatrix $config "all" -filters "operatingSystem=windows.*","framework=.*","additionalArguments=mode=test"
         $matrix.Length | Should -Be 2
-        $matrix[0].Name | Should -Be "windows2019_net461_modetest"
+        $matrix[0].Name | Should -Be "windows2022_net461_modetest"
     }
 
     It "Should handle no matrix key/value filter matches" {

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
@@ -10,7 +10,7 @@ BeforeAll {
     },
     "matrix": {
         "operatingSystem": [
-          "windows-2019",
+          "windows-2022",
           "ubuntu-18.04",
           "macOS-10.15"
         ],
@@ -25,14 +25,14 @@ BeforeAll {
     },
     "include": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": ["net461", "netcoreapp2.1", "net50"],
             "additionalArguments": "--enableWindowsFoo"
         }
     ],
     "exclude": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": "net461"
         },
         {
@@ -228,17 +228,17 @@ Describe "Matrix-Reverse-Lookup" -Tag "lookup" {
          @{ index = 1; expected = @(0,0,0,1) }
          @{ index = 2; expected = @(0,0,0,2) }
          @{ index = 3; expected = @(0,0,0,3) }
-                      
+
          @{ index = 4; expected = @(0,0,1,0) }
          @{ index = 5; expected = @(0,0,1,1) }
          @{ index = 6; expected = @(0,0,1,2) }
          @{ index = 7; expected = @(0,0,1,3) }
-                      
+
          @{ index = 8; expected = @(0,1,0,0) }
          @{ index = 9; expected = @(0,1,0,1) }
          @{ index = 10; expected = @(0,1,0,2) }
          @{ index = 11; expected = @(0,1,0,3) }
-                      
+
          @{ index = 12; expected = @(0,1,1,0) }
          @{ index = 13; expected = @(0,1,1,1) }
          @{ index = 14; expected = @(0,1,1,2) }
@@ -273,7 +273,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     },
     "matrix": {
         "operatingSystem": [
-          "windows-2019",
+          "windows-2022",
           "ubuntu-18.04",
           "macOS-10.15"
         ],
@@ -288,7 +288,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     },
     "include": [
       {
-        "operatingSystem": "windows-2019",
+        "operatingSystem": "windows-2022",
         "framework": "net461",
         "additionalTestArguments": "/p:UseProjectReferenceToAzureClients=true"
       }
@@ -315,7 +315,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
         $matrix = GenerateFullMatrix $generateConfig.matrixParameters $generateconfig.displayNamesLookup
 
         $element = GetNdMatrixElement @(0, 0, 0) $matrix $dimensions
-        $element.name | Should -Be "windows2019_net461"
+        $element.name | Should -Be "windows2022_net461"
 
         $element = GetNdMatrixElement @(1, 1, 1) $matrix $dimensions
         $element.name | Should -Be "ubuntu1804_netcoreapp21_withFoo"
@@ -330,7 +330,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
         $matrix.Count | Should -Be 12
 
         $element = $matrix[0].parameters
-        $element.operatingSystem | Should -Be "windows-2019"
+        $element.operatingSystem | Should -Be "windows-2022"
         $element.framework | Should -Be "net461"
         $element.additionalArguments | Should -Be ""
 
@@ -346,7 +346,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     }
 
     It "Should initialize a sparse matrix from an N-dimensional matrix" -TestCases @(
-        @{ i = 0; name = "windows2019_net461"; operatingSystem = "windows-2019"; framework = "net461"; additionalArguments = ""; }
+        @{ i = 0; name = "windows2022_net461"; operatingSystem = "windows-2022"; framework = "net461"; additionalArguments = ""; }
         @{ i = 1; name = "ubuntu1804_netcoreapp21_withfoo"; operatingSystem = "ubuntu-18.04"; framework = "netcoreapp2.1"; additionalArguments = "--enableFoo"; }
         @{ i = 2; name = "macOS1015_net461"; operatingSystem = "macOS-10.15"; framework = "net461"; additionalArguments = ""; }
     ) {
@@ -380,7 +380,7 @@ Describe "Config File Object Conversion" -Tag "convert" {
 
     It "Should convert a matrix config" {
         $config.matrixParameters[0].Name | Should -Be "operatingSystem"
-        $config.matrixParameters[0].Flatten()[0].Value | Should -Be "windows-2019"
+        $config.matrixParameters[0].Flatten()[0].Value | Should -Be "windows-2022"
 
         $config.displayNamesLookup | Should -BeOfType [Hashtable]
         $config.displayNamesLookup["--enableFoo"] | Should -Be "withFoo"
@@ -425,13 +425,13 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 8
 
-        $matrix[0].name | Should -Be "windows2019_netcoreapp21"
-        $matrix[0].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[0].name | Should -Be "windows2022_netcoreapp21"
+        $matrix[0].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[0].parameters.framework | Should -Be "netcoreapp2.1"
         $matrix[0].parameters.additionalArguments | Should -Be ""
 
-        $matrix[1].name | Should -Be "windows2019_netcoreapp21_withfoo"
-        $matrix[1].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[1].name | Should -Be "windows2022_netcoreapp21_withfoo"
+        $matrix[1].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[1].parameters.framework | Should -Be "netcoreapp2.1"
         $matrix[1].parameters.additionalArguments | Should -Be "--enableFoo"
 
@@ -445,9 +445,9 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $matrix[4].parameters.operatingSystem | Should -Be "macOS-10.15"
         $matrix[4].parameters.additionalArguments | Should -Be ""
 
-        $matrix[7].name | Should -Be "windows2019_net50_enableWindowsFoo"
+        $matrix[7].name | Should -Be "windows2022_net50_enableWindowsFoo"
         $matrix[7].parameters.framework | Should -Be "net50"
-        $matrix[7].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[7].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[7].parameters.additionalArguments | Should -Be "--enableWindowsFoo"
     }
 
@@ -456,7 +456,7 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
 {
     "include": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": "net461"
         }
     ]
@@ -466,14 +466,14 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $config = GetMatrixConfigFromJson $matrixConfigForIncludeOnly
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 1
-        $matrix[0].name | Should -Be "windows2019_net461"
+        $matrix[0].name | Should -Be "windows2022_net461"
     }
 
     It "Should parse a config with an empty include" {
         $matrixConfigForIncludeOnly = @"
 {
     "matrix": {
-        "operatingSystem": "windows-2019",
+        "operatingSystem": "windows-2022",
         "framework": "net461"
     }
 }
@@ -482,7 +482,7 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $config = GetMatrixConfigFromJson $matrixConfigForIncludeOnly
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 1
-        $matrix[0].name | Should -Be "windows2019_net461"
+        $matrix[0].name | Should -Be "windows2022_net461"
     }
 }
 

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -82,8 +82,8 @@ jobs:
         BuildType: Debug
 
       WindowsX86_Release_MapFiles_UnitTests:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=ON'
@@ -180,8 +180,8 @@ jobs:
         BuildType: Debug
 
       Windows_Preconditions_UnitTests_Samples:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=ON'
@@ -233,8 +233,8 @@ jobs:
         BuildType: Debug
 
       Windows_Release_Samples_MapFiles:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF -DTRANSPORT_PAHO=ON'
@@ -434,8 +434,8 @@ jobs:
 
 - job: GenerateReleaseArtifacts
   pool:
-    name: azsdk-pool-mms-win-2019-general
-    vmImage: MMS2019
+    name: azsdk-pool-mms-win-2022-general
+    vmImage: windows-2022
   variables:
     Package.EnableSBOMSigning: true
   steps:

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -16,8 +16,8 @@ jobs:
           test_type: 'iot'
           os: 'linux'
         Win_x64_with_iot_samples:
-          Pool: azsdk-pool-mms-win-2019-general
-          OSVmImage: MMS2019
+          Pool: azsdk-pool-mms-win-2022-general
+          OSVmImage: windows-2022
           vcpkg.deps: 'curl[winssl] cmocka paho-mqtt'
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
@@ -42,16 +42,16 @@ jobs:
         #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         #   build.args: ' -DTRANSPO.RT_CURL=ON -DAZ_PLATFORM_IMPL=POSIX'
         # Win_x86_with_sampldes:
-        #   Pool: azsdk-pool-mms-win-2019-general
-        #   OSVmImage: MMS2019
+        #   Pool: azsdk-pool-mms-win-2022-general
+        #   OSVmImage: windows-2022
         #   vcpkg.deps: 'curl[winssl]'
         #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
         #   CMAKE_GENERATOR_PLATFORM: Win32
         #   build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=WIN32'
         # Win_x64_with_samples:
-        #   Pool: azsdk-pool-mms-win-2019-general
-        #   OSVmImage: MMS2019
+        #   Pool: azsdk-pool-mms-win-2022-general
+        #   OSVmImage: windows-2022
         #   vcpkg.deps: 'curl[winssl]'
         #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         #   CMAKE_GENERATOR: 'Visual Studio 16 2019'

--- a/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/examples/Linux/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -11,8 +11,8 @@ stages:
         environment: github
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:
@@ -37,15 +37,15 @@ stages:
                     RepoId: $(Build.Repository.Name)
                     WorkingDirectory: $(Build.SourcesDirectory)
                     ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
-                
+
       - deployment: PublishDocs
         displayName: Publish Docs to GitHub pages
         condition: ne(variables['Skip.PublishDocs'], 'true')
         environment: githubio
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:
@@ -70,8 +70,8 @@ stages:
         environment: github
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/pipelines/templates/jobs/docindex.yml
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/pipelines/templates/jobs/docindex.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: CreateDocIndex
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
       - task: UsePythonVersion@0
         displayName: 'Use Python 3.6'
@@ -19,7 +19,7 @@ jobs:
         displayName: 'Generate Doc Index'
         inputs:
           pwsh: true
-          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1 
+          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1
           arguments: >
             -Docfx $(docfxPath)
             -RepoRoot $(Build.SourcesDirectory)
@@ -38,14 +38,14 @@ jobs:
           Copy-Item -Path $(Build.SourcesDirectory)/eng/* -Destination ./ -Recurse -Force
           echo "##vso[task.setvariable variable=toolPath]$(Build.BinariesDirectory)"
         workingDirectory: $(Build.BinariesDirectory)
-        displayName: Move eng/common to Tool Directory   
+        displayName: Move eng/common to Tool Directory
 
       - task: PublishPipelineArtifact@0
         condition: succeeded()
         inputs:
           artifactName: "Doc.Index"
           targetPath: $(Build.ArtifactStagingDirectory)/docfx_project/_site
-          
+
       - pwsh: |
           git checkout -b gh-pages-local --track origin/gh-pages-root -f
         workingDirectory: $(Build.SourcesDirectory)

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/pipelines/templates/steps/docindex.yml
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/pipelines/templates/steps/docindex.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: CreateDocIndex
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
       - task: UsePythonVersion@0
         displayName: 'Use Python 3.6'
@@ -19,7 +19,7 @@ jobs:
         displayName: 'Generate Doc Index'
         inputs:
           pwsh: true
-          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1 
+          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1
           arguments: >
             -Docfx $(docfxPath)
             -RepoRoot $(Build.SourcesDirectory)
@@ -38,14 +38,14 @@ jobs:
           Copy-Item -Path $(Build.SourcesDirectory)/eng/* -Destination ./ -Recurse -Force
           echo "##vso[task.setvariable variable=toolPath]$(Build.BinariesDirectory)"
         workingDirectory: $(Build.BinariesDirectory)
-        displayName: Move eng/common to Tool Directory   
+        displayName: Move eng/common to Tool Directory
 
       - task: PublishPipelineArtifact@0
         condition: succeeded()
         inputs:
           artifactName: "Doc.Index"
           targetPath: $(Build.ArtifactStagingDirectory)/docfx_project/_site
-          
+
       - pwsh: |
           git checkout -b gh-pages-local --track origin/gh-pages-root -f
         workingDirectory: $(Build.SourcesDirectory)

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/Verify-AgentOS.ps1
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/Verify-AgentOS.ps1
@@ -8,7 +8,7 @@ function Throw-InvalidOperatingSystem {
     throw "Invalid operating system detected. Operating system was: $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription), expected image was: $AgentImage"
 }
 
-if ($IsWindows -and $AgentImage -match "windows|win|MMS2019") {
+if ($IsWindows -and $AgentImage -match "windows|win|windows-2022") {
     $osName = "Windows"
 } elseif ($IsLinux -and $AgentImage -match "ubuntu") {
     $osName = "Linux"

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/README.md
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/README.md
@@ -100,7 +100,7 @@ Example:
 ```
 "matrix": {
   "operatingSystem": [
-    "windows-2019",
+    "windows-2022",
     "ubuntu-18.04",
     "macOS-10.15"
   ],
@@ -386,14 +386,14 @@ In the matrix job output that azure pipelines consumes, the format is a dictiona
     "framework": "net50",
     "operatingSystem": "ubuntu-18.04"
   },
-  "netcoreapp21_windows2019": {
+  "netcoreapp21_windows2022": {
     "framework": "netcoreapp2.1",
-    "operatingSystem": "windows-2019"
+    "operatingSystem": "windows-2022"
   },
-  "UseProjectRef_net461_windows2019": {
+  "UseProjectRef_net461_windows2022": {
     "additionalTestArguments": "/p:UseProjectReferenceToAzureClients=true",
     "framework": "net461",
-    "operatingSystem": "windows-2019"
+    "operatingSystem": "windows-2022"
   }
 }
 ```
@@ -510,7 +510,7 @@ Given a matrix like below with `JavaTestVersion` marked as a non-sparse paramete
 {
   "matrix": {
     "Agent": {
-      "windows-2019": { "OSVmImage": "MMS2019", "Pool": "azsdk-pool-mms-win-2019-general" },
+      "windows-2022": { "OSVmImage": "windows-2022", "Pool": "azsdk-pool-mms-win-2022-general" },
       "ubuntu-1804": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" },
       "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/samples/matrix.json
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/samples/matrix.json
@@ -5,7 +5,7 @@
   "matrix": {
     "Agent": {
       "ubuntu": { "OSVmImage": "ubuntu-18.04", "Pool": "Azure Pipelines" },
-      "windows": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" },
+      "windows": { "OSVmImage": "windows-2022", "Pool": "Azure Pipelines" },
       "macOS": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },
     "TestTargetFramework": [ "netcoreapp2.1", "net461", "net5.0" ]
@@ -13,7 +13,7 @@
   "include": [
     {
       "Agent": {
-        "windows": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" }
+        "windows": { "OSVmImage": "windows-2022", "Pool": "Azure Pipelines" }
       },
       "TestTargetFramework": [ "net461", "net5.0" ],
       "AdditionalTestArguments": "/p:UseProjectReferenceToAzureClients=true"
@@ -21,7 +21,7 @@
   ],
   "exclude": [
     {
-      "OSVmImage": "MMS2019",
+      "OSVmImage": "windows-2022",
       "framework": "netcoreapp2.1"
     }
   ]

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.filter.tests.ps1
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.filter.tests.ps1
@@ -6,7 +6,7 @@ BeforeAll {
     $matrixConfig = @"
 {
     "matrix": {
-        "operatingSystem": [ "windows-2019", "ubuntu-18.04", "macOS-10.15" ],
+        "operatingSystem": [ "windows-2022", "ubuntu-18.04", "macOS-10.15" ],
         "framework": [ "net461", "netcoreapp2.1" ],
         "additionalArguments": [ "", "mode=test" ]
     }
@@ -17,8 +17,8 @@ BeforeAll {
 
 Describe "Matrix Filter" -Tag "filter" {
     It "Should filter by matrix display name" -TestCases @(
-        @{ regex = "windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ regex = "windows2019_netcoreapp21_modetest"; expectedFirst = "windows2019_netcoreapp21_modetest"; length = 1 }
+        @{ regex = "windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ regex = "windows2022_netcoreapp21_modetest"; expectedFirst = "windows2022_netcoreapp21_modetest"; length = 1 }
         @{ regex = ".*ubuntu.*"; expectedFirst = "ubuntu1804_net461"; length = 4 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" $regex
@@ -33,11 +33,11 @@ Describe "Matrix Filter" -Tag "filter" {
     }
 
     It "Should filter by matrix key/value" -TestCases @(
-        @{ filterString = "operatingSystem=windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "operatingSystem=windows-2019"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "framework=.*"; expectedFirst = "windows2019_net461"; length = 12 }
-        @{ filterString = "additionalArguments=mode=test"; expectedFirst = "windows2019_net461_modetest"; length = 6 }
-        @{ filterString = "additionalArguments=^$"; expectedFirst = "windows2019_net461"; length = 6 }
+        @{ filterString = "operatingSystem=windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "operatingSystem=windows-2022"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "framework=.*"; expectedFirst = "windows2022_net461"; length = 12 }
+        @{ filterString = "additionalArguments=mode=test"; expectedFirst = "windows2022_net461_modetest"; length = 6 }
+        @{ filterString = "additionalArguments=^$"; expectedFirst = "windows2022_net461"; length = 6 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" -filters @($filterString)
         $matrix.Length | Should -Be $length
@@ -45,8 +45,8 @@ Describe "Matrix Filter" -Tag "filter" {
     }
 
     It "Should filter by optional matrix key/value" -TestCases @(
-        @{ filterString = "operatingSystem=^$|windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "doesnotexist=^$|.*"; expectedFirst = "windows2019_net461"; length = 12 }
+        @{ filterString = "operatingSystem=^$|windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "doesnotexist=^$|.*"; expectedFirst = "windows2022_net461"; length = 12 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" -filters @($filterString)
         $matrix.Length | Should -Be $length
@@ -56,7 +56,7 @@ Describe "Matrix Filter" -Tag "filter" {
     It "Should handle multiple matrix key/value filters " {
         [array]$matrix = GenerateMatrix $config "all" -filters "operatingSystem=windows.*","framework=.*","additionalArguments=mode=test"
         $matrix.Length | Should -Be 2
-        $matrix[0].Name | Should -Be "windows2019_net461_modetest"
+        $matrix[0].Name | Should -Be "windows2022_net461_modetest"
     }
 
     It "Should handle no matrix key/value filter matches" {

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
@@ -10,7 +10,7 @@ BeforeAll {
     },
     "matrix": {
         "operatingSystem": [
-          "windows-2019",
+          "windows-2022",
           "ubuntu-18.04",
           "macOS-10.15"
         ],
@@ -25,14 +25,14 @@ BeforeAll {
     },
     "include": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": ["net461", "netcoreapp2.1", "net50"],
             "additionalArguments": "--enableWindowsFoo"
         }
     ],
     "exclude": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": "net461"
         },
         {
@@ -228,17 +228,17 @@ Describe "Matrix-Reverse-Lookup" -Tag "lookup" {
          @{ index = 1; expected = @(0,0,0,1) }
          @{ index = 2; expected = @(0,0,0,2) }
          @{ index = 3; expected = @(0,0,0,3) }
-                      
+
          @{ index = 4; expected = @(0,0,1,0) }
          @{ index = 5; expected = @(0,0,1,1) }
          @{ index = 6; expected = @(0,0,1,2) }
          @{ index = 7; expected = @(0,0,1,3) }
-                      
+
          @{ index = 8; expected = @(0,1,0,0) }
          @{ index = 9; expected = @(0,1,0,1) }
          @{ index = 10; expected = @(0,1,0,2) }
          @{ index = 11; expected = @(0,1,0,3) }
-                      
+
          @{ index = 12; expected = @(0,1,1,0) }
          @{ index = 13; expected = @(0,1,1,1) }
          @{ index = 14; expected = @(0,1,1,2) }
@@ -273,7 +273,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     },
     "matrix": {
         "operatingSystem": [
-          "windows-2019",
+          "windows-2022",
           "ubuntu-18.04",
           "macOS-10.15"
         ],
@@ -288,7 +288,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     },
     "include": [
       {
-        "operatingSystem": "windows-2019",
+        "operatingSystem": "windows-2022",
         "framework": "net461",
         "additionalTestArguments": "/p:UseProjectReferenceToAzureClients=true"
       }
@@ -315,7 +315,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
         $matrix = GenerateFullMatrix $generateConfig.matrixParameters $generateconfig.displayNamesLookup
 
         $element = GetNdMatrixElement @(0, 0, 0) $matrix $dimensions
-        $element.name | Should -Be "windows2019_net461"
+        $element.name | Should -Be "windows2022_net461"
 
         $element = GetNdMatrixElement @(1, 1, 1) $matrix $dimensions
         $element.name | Should -Be "ubuntu1804_netcoreapp21_withFoo"
@@ -330,7 +330,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
         $matrix.Count | Should -Be 12
 
         $element = $matrix[0].parameters
-        $element.operatingSystem | Should -Be "windows-2019"
+        $element.operatingSystem | Should -Be "windows-2022"
         $element.framework | Should -Be "net461"
         $element.additionalArguments | Should -Be ""
 
@@ -346,7 +346,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     }
 
     It "Should initialize a sparse matrix from an N-dimensional matrix" -TestCases @(
-        @{ i = 0; name = "windows2019_net461"; operatingSystem = "windows-2019"; framework = "net461"; additionalArguments = ""; }
+        @{ i = 0; name = "windows2022_net461"; operatingSystem = "windows-2022"; framework = "net461"; additionalArguments = ""; }
         @{ i = 1; name = "ubuntu1804_netcoreapp21_withfoo"; operatingSystem = "ubuntu-18.04"; framework = "netcoreapp2.1"; additionalArguments = "--enableFoo"; }
         @{ i = 2; name = "macOS1015_net461"; operatingSystem = "macOS-10.15"; framework = "net461"; additionalArguments = ""; }
     ) {
@@ -380,7 +380,7 @@ Describe "Config File Object Conversion" -Tag "convert" {
 
     It "Should convert a matrix config" {
         $config.matrixParameters[0].Name | Should -Be "operatingSystem"
-        $config.matrixParameters[0].Flatten()[0].Value | Should -Be "windows-2019"
+        $config.matrixParameters[0].Flatten()[0].Value | Should -Be "windows-2022"
 
         $config.displayNamesLookup | Should -BeOfType [Hashtable]
         $config.displayNamesLookup["--enableFoo"] | Should -Be "withFoo"
@@ -425,13 +425,13 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 8
 
-        $matrix[0].name | Should -Be "windows2019_netcoreapp21"
-        $matrix[0].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[0].name | Should -Be "windows2022_netcoreapp21"
+        $matrix[0].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[0].parameters.framework | Should -Be "netcoreapp2.1"
         $matrix[0].parameters.additionalArguments | Should -Be ""
 
-        $matrix[1].name | Should -Be "windows2019_netcoreapp21_withfoo"
-        $matrix[1].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[1].name | Should -Be "windows2022_netcoreapp21_withfoo"
+        $matrix[1].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[1].parameters.framework | Should -Be "netcoreapp2.1"
         $matrix[1].parameters.additionalArguments | Should -Be "--enableFoo"
 
@@ -445,9 +445,9 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $matrix[4].parameters.operatingSystem | Should -Be "macOS-10.15"
         $matrix[4].parameters.additionalArguments | Should -Be ""
 
-        $matrix[7].name | Should -Be "windows2019_net50_enableWindowsFoo"
+        $matrix[7].name | Should -Be "windows2022_net50_enableWindowsFoo"
         $matrix[7].parameters.framework | Should -Be "net50"
-        $matrix[7].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[7].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[7].parameters.additionalArguments | Should -Be "--enableWindowsFoo"
     }
 
@@ -456,7 +456,7 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
 {
     "include": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": "net461"
         }
     ]
@@ -466,14 +466,14 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $config = GetMatrixConfigFromJson $matrixConfigForIncludeOnly
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 1
-        $matrix[0].name | Should -Be "windows2019_net461"
+        $matrix[0].name | Should -Be "windows2022_net461"
     }
 
     It "Should parse a config with an empty include" {
         $matrixConfigForIncludeOnly = @"
 {
     "matrix": {
-        "operatingSystem": "windows-2019",
+        "operatingSystem": "windows-2022",
         "framework": "net461"
     }
 }
@@ -482,7 +482,7 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $config = GetMatrixConfigFromJson $matrixConfigForIncludeOnly
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 1
-        $matrix[0].name | Should -Be "windows2019_net461"
+        $matrix[0].name | Should -Be "windows2022_net461"
     }
 }
 

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -82,8 +82,8 @@ jobs:
         BuildType: Debug
 
       WindowsX86_Release_MapFiles_UnitTests:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=ON'
@@ -180,8 +180,8 @@ jobs:
         BuildType: Debug
 
       Windows_Preconditions_UnitTests_Samples:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=ON'
@@ -233,8 +233,8 @@ jobs:
         BuildType: Debug
 
       Windows_Release_Samples_MapFiles:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF -DTRANSPORT_PAHO=ON'
@@ -434,8 +434,8 @@ jobs:
 
 - job: GenerateReleaseArtifacts
   pool:
-    name: azsdk-pool-mms-win-2019-general
-    vmImage: MMS2019
+    name: azsdk-pool-mms-win-2022-general
+    vmImage: windows-2022
   variables:
     Package.EnableSBOMSigning: true
   steps:

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -16,8 +16,8 @@ jobs:
           test_type: 'iot'
           os: 'linux'
         Win_x64_with_iot_samples:
-          Pool: azsdk-pool-mms-win-2019-general
-          OSVmImage: MMS2019
+          Pool: azsdk-pool-mms-win-2022-general
+          OSVmImage: windows-2022
           vcpkg.deps: 'curl[winssl] cmocka paho-mqtt'
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
@@ -42,16 +42,16 @@ jobs:
         #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         #   build.args: ' -DTRANSPO.RT_CURL=ON -DAZ_PLATFORM_IMPL=POSIX'
         # Win_x86_with_sampldes:
-        #   Pool: azsdk-pool-mms-win-2019-general
-        #   OSVmImage: MMS2019
+        #   Pool: azsdk-pool-mms-win-2022-general
+        #   OSVmImage: windows-2022
         #   vcpkg.deps: 'curl[winssl]'
         #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
         #   CMAKE_GENERATOR_PLATFORM: Win32
         #   build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=WIN32'
         # Win_x64_with_samples:
-        #   Pool: azsdk-pool-mms-win-2019-general
-        #   OSVmImage: MMS2019
+        #   Pool: azsdk-pool-mms-win-2022-general
+        #   OSVmImage: windows-2022
         #   vcpkg.deps: 'curl[winssl]'
         #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         #   CMAKE_GENERATOR: 'Visual Studio 16 2019'

--- a/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/examples/WIN32/netxduo/addons/azure_iot/azure-sdk-for-c/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -11,8 +11,8 @@ stages:
         environment: github
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:
@@ -37,15 +37,15 @@ stages:
                     RepoId: $(Build.Repository.Name)
                     WorkingDirectory: $(Build.SourcesDirectory)
                     ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
-                
+
       - deployment: PublishDocs
         displayName: Publish Docs to GitHub pages
         condition: ne(variables['Skip.PublishDocs'], 'true')
         environment: githubio
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:
@@ -70,8 +70,8 @@ stages:
         environment: github
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:

--- a/externals/azure-sdk-for-c/eng/common/pipelines/templates/jobs/docindex.yml
+++ b/externals/azure-sdk-for-c/eng/common/pipelines/templates/jobs/docindex.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: CreateDocIndex
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
       - task: UsePythonVersion@0
         displayName: 'Use Python 3.9'
@@ -19,7 +19,7 @@ jobs:
         displayName: 'Generate Doc Index'
         inputs:
           pwsh: true
-          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1 
+          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1
           arguments: >
             -Docfx $(docfxPath)
             -RepoRoot $(Build.SourcesDirectory)
@@ -34,14 +34,14 @@ jobs:
           Copy-Item -Path $(Build.SourcesDirectory)/eng/* -Destination ./ -Recurse -Force
           echo "##vso[task.setvariable variable=toolPath]$(Build.BinariesDirectory)"
         workingDirectory: $(Build.BinariesDirectory)
-        displayName: Move eng/common to Tool Directory   
+        displayName: Move eng/common to Tool Directory
 
       - task: PublishPipelineArtifact@0
         condition: succeeded()
         inputs:
           artifactName: "Doc.Index"
           targetPath: $(Build.ArtifactStagingDirectory)/docfx_project/_site
-          
+
       - pwsh: |
           git checkout -b gh-pages-local --track origin/gh-pages-root -f
         workingDirectory: $(Build.SourcesDirectory)

--- a/externals/azure-sdk-for-c/eng/common/scripts/Verify-AgentOS.ps1
+++ b/externals/azure-sdk-for-c/eng/common/scripts/Verify-AgentOS.ps1
@@ -8,7 +8,7 @@ function Throw-InvalidOperatingSystem {
     throw "Invalid operating system detected. Operating system was: $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription), expected image was: $AgentImage"
 }
 
-if ($IsWindows -and $AgentImage -match "windows|win|MMS2019") {
+if ($IsWindows -and $AgentImage -match "windows|win|windows-2022") {
     $osName = "Windows"
 } elseif ($IsLinux -and $AgentImage -match "ubuntu") {
     $osName = "Linux"

--- a/externals/azure-sdk-for-c/eng/common/scripts/job-matrix/README.md
+++ b/externals/azure-sdk-for-c/eng/common/scripts/job-matrix/README.md
@@ -100,7 +100,7 @@ Example:
 ```
 "matrix": {
   "operatingSystem": [
-    "windows-2019",
+    "windows-2022",
     "ubuntu-18.04",
     "macOS-10.15"
   ],
@@ -386,14 +386,14 @@ In the matrix job output that azure pipelines consumes, the format is a dictiona
     "framework": "net50",
     "operatingSystem": "ubuntu-18.04"
   },
-  "netcoreapp21_windows2019": {
+  "netcoreapp21_windows2022": {
     "framework": "netcoreapp2.1",
-    "operatingSystem": "windows-2019"
+    "operatingSystem": "windows-2022"
   },
-  "UseProjectRef_net461_windows2019": {
+  "UseProjectRef_net461_windows2022": {
     "additionalTestArguments": "/p:UseProjectReferenceToAzureClients=true",
     "framework": "net461",
-    "operatingSystem": "windows-2019"
+    "operatingSystem": "windows-2022"
   }
 }
 ```
@@ -510,7 +510,7 @@ Given a matrix like below with `JavaTestVersion` marked as a non-sparse paramete
 {
   "matrix": {
     "Agent": {
-      "windows-2019": { "OSVmImage": "MMS2019", "Pool": "azsdk-pool-mms-win-2019-general" },
+      "windows-2022": { "OSVmImage": "windows-2022", "Pool": "azsdk-pool-mms-win-2022-general" },
       "ubuntu-1804": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" },
       "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },

--- a/externals/azure-sdk-for-c/eng/common/scripts/job-matrix/samples/matrix.json
+++ b/externals/azure-sdk-for-c/eng/common/scripts/job-matrix/samples/matrix.json
@@ -5,7 +5,7 @@
   "matrix": {
     "Agent": {
       "ubuntu": { "OSVmImage": "ubuntu-18.04", "Pool": "Azure Pipelines" },
-      "windows": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" },
+      "windows": { "OSVmImage": "windows-2022", "Pool": "Azure Pipelines" },
       "macOS": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },
     "TestTargetFramework": [ "netcoreapp2.1", "net461", "net5.0" ]
@@ -13,7 +13,7 @@
   "include": [
     {
       "Agent": {
-        "windows": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" }
+        "windows": { "OSVmImage": "windows-2022", "Pool": "Azure Pipelines" }
       },
       "TestTargetFramework": [ "net461", "net5.0" ],
       "AdditionalTestArguments": "/p:UseProjectReferenceToAzureClients=true"
@@ -21,7 +21,7 @@
   ],
   "exclude": [
     {
-      "OSVmImage": "MMS2019",
+      "OSVmImage": "windows-2022",
       "framework": "netcoreapp2.1"
     }
   ]

--- a/externals/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.filter.tests.ps1
+++ b/externals/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.filter.tests.ps1
@@ -6,7 +6,7 @@ BeforeAll {
     $matrixConfig = @"
 {
     "matrix": {
-        "operatingSystem": [ "windows-2019", "ubuntu-18.04", "macOS-10.15" ],
+        "operatingSystem": [ "windows-2022", "ubuntu-18.04", "macOS-10.15" ],
         "framework": [ "net461", "netcoreapp2.1" ],
         "additionalArguments": [ "", "mode=test" ]
     }
@@ -17,8 +17,8 @@ BeforeAll {
 
 Describe "Matrix Filter" -Tag "filter" {
     It "Should filter by matrix display name" -TestCases @(
-        @{ regex = "windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ regex = "windows2019_netcoreapp21_modetest"; expectedFirst = "windows2019_netcoreapp21_modetest"; length = 1 }
+        @{ regex = "windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ regex = "windows2022_netcoreapp21_modetest"; expectedFirst = "windows2022_netcoreapp21_modetest"; length = 1 }
         @{ regex = ".*ubuntu.*"; expectedFirst = "ubuntu1804_net461"; length = 4 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" $regex
@@ -33,11 +33,11 @@ Describe "Matrix Filter" -Tag "filter" {
     }
 
     It "Should filter by matrix key/value" -TestCases @(
-        @{ filterString = "operatingSystem=windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "operatingSystem=windows-2019"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "framework=.*"; expectedFirst = "windows2019_net461"; length = 12 }
-        @{ filterString = "additionalArguments=mode=test"; expectedFirst = "windows2019_net461_modetest"; length = 6 }
-        @{ filterString = "additionalArguments=^$"; expectedFirst = "windows2019_net461"; length = 6 }
+        @{ filterString = "operatingSystem=windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "operatingSystem=windows-2022"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "framework=.*"; expectedFirst = "windows2022_net461"; length = 12 }
+        @{ filterString = "additionalArguments=mode=test"; expectedFirst = "windows2022_net461_modetest"; length = 6 }
+        @{ filterString = "additionalArguments=^$"; expectedFirst = "windows2022_net461"; length = 6 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" -filters @($filterString)
         $matrix.Length | Should -Be $length
@@ -45,8 +45,8 @@ Describe "Matrix Filter" -Tag "filter" {
     }
 
     It "Should filter by optional matrix key/value" -TestCases @(
-        @{ filterString = "operatingSystem=^$|windows.*"; expectedFirst = "windows2019_net461"; length = 4 }
-        @{ filterString = "doesnotexist=^$|.*"; expectedFirst = "windows2019_net461"; length = 12 }
+        @{ filterString = "operatingSystem=^$|windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
+        @{ filterString = "doesnotexist=^$|.*"; expectedFirst = "windows2022_net461"; length = 12 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" -filters @($filterString)
         $matrix.Length | Should -Be $length
@@ -56,7 +56,7 @@ Describe "Matrix Filter" -Tag "filter" {
     It "Should handle multiple matrix key/value filters " {
         [array]$matrix = GenerateMatrix $config "all" -filters "operatingSystem=windows.*","framework=.*","additionalArguments=mode=test"
         $matrix.Length | Should -Be 2
-        $matrix[0].Name | Should -Be "windows2019_net461_modetest"
+        $matrix[0].Name | Should -Be "windows2022_net461_modetest"
     }
 
     It "Should handle no matrix key/value filter matches" {

--- a/externals/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
+++ b/externals/azure-sdk-for-c/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
@@ -10,7 +10,7 @@ BeforeAll {
     },
     "matrix": {
         "operatingSystem": [
-          "windows-2019",
+          "windows-2022",
           "ubuntu-18.04",
           "macOS-10.15"
         ],
@@ -25,14 +25,14 @@ BeforeAll {
     },
     "include": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": ["net461", "netcoreapp2.1", "net50"],
             "additionalArguments": "--enableWindowsFoo"
         }
     ],
     "exclude": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": "net461"
         },
         {
@@ -228,17 +228,17 @@ Describe "Matrix-Reverse-Lookup" -Tag "lookup" {
          @{ index = 1; expected = @(0,0,0,1) }
          @{ index = 2; expected = @(0,0,0,2) }
          @{ index = 3; expected = @(0,0,0,3) }
-                      
+
          @{ index = 4; expected = @(0,0,1,0) }
          @{ index = 5; expected = @(0,0,1,1) }
          @{ index = 6; expected = @(0,0,1,2) }
          @{ index = 7; expected = @(0,0,1,3) }
-                      
+
          @{ index = 8; expected = @(0,1,0,0) }
          @{ index = 9; expected = @(0,1,0,1) }
          @{ index = 10; expected = @(0,1,0,2) }
          @{ index = 11; expected = @(0,1,0,3) }
-                      
+
          @{ index = 12; expected = @(0,1,1,0) }
          @{ index = 13; expected = @(0,1,1,1) }
          @{ index = 14; expected = @(0,1,1,2) }
@@ -273,7 +273,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     },
     "matrix": {
         "operatingSystem": [
-          "windows-2019",
+          "windows-2022",
           "ubuntu-18.04",
           "macOS-10.15"
         ],
@@ -288,7 +288,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     },
     "include": [
       {
-        "operatingSystem": "windows-2019",
+        "operatingSystem": "windows-2022",
         "framework": "net461",
         "additionalTestArguments": "/p:UseProjectReferenceToAzureClients=true"
       }
@@ -315,7 +315,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
         $matrix = GenerateFullMatrix $generateConfig.matrixParameters $generateconfig.displayNamesLookup
 
         $element = GetNdMatrixElement @(0, 0, 0) $matrix $dimensions
-        $element.name | Should -Be "windows2019_net461"
+        $element.name | Should -Be "windows2022_net461"
 
         $element = GetNdMatrixElement @(1, 1, 1) $matrix $dimensions
         $element.name | Should -Be "ubuntu1804_netcoreapp21_withFoo"
@@ -330,7 +330,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
         $matrix.Count | Should -Be 12
 
         $element = $matrix[0].parameters
-        $element.operatingSystem | Should -Be "windows-2019"
+        $element.operatingSystem | Should -Be "windows-2022"
         $element.framework | Should -Be "net461"
         $element.additionalArguments | Should -Be ""
 
@@ -346,7 +346,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     }
 
     It "Should initialize a sparse matrix from an N-dimensional matrix" -TestCases @(
-        @{ i = 0; name = "windows2019_net461"; operatingSystem = "windows-2019"; framework = "net461"; additionalArguments = ""; }
+        @{ i = 0; name = "windows2022_net461"; operatingSystem = "windows-2022"; framework = "net461"; additionalArguments = ""; }
         @{ i = 1; name = "ubuntu1804_netcoreapp21_withfoo"; operatingSystem = "ubuntu-18.04"; framework = "netcoreapp2.1"; additionalArguments = "--enableFoo"; }
         @{ i = 2; name = "macOS1015_net461"; operatingSystem = "macOS-10.15"; framework = "net461"; additionalArguments = ""; }
     ) {
@@ -380,7 +380,7 @@ Describe "Config File Object Conversion" -Tag "convert" {
 
     It "Should convert a matrix config" {
         $config.matrixParameters[0].Name | Should -Be "operatingSystem"
-        $config.matrixParameters[0].Flatten()[0].Value | Should -Be "windows-2019"
+        $config.matrixParameters[0].Flatten()[0].Value | Should -Be "windows-2022"
 
         $config.displayNamesLookup | Should -BeOfType [Hashtable]
         $config.displayNamesLookup["--enableFoo"] | Should -Be "withFoo"
@@ -425,13 +425,13 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 8
 
-        $matrix[0].name | Should -Be "windows2019_netcoreapp21"
-        $matrix[0].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[0].name | Should -Be "windows2022_netcoreapp21"
+        $matrix[0].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[0].parameters.framework | Should -Be "netcoreapp2.1"
         $matrix[0].parameters.additionalArguments | Should -Be ""
 
-        $matrix[1].name | Should -Be "windows2019_netcoreapp21_withfoo"
-        $matrix[1].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[1].name | Should -Be "windows2022_netcoreapp21_withfoo"
+        $matrix[1].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[1].parameters.framework | Should -Be "netcoreapp2.1"
         $matrix[1].parameters.additionalArguments | Should -Be "--enableFoo"
 
@@ -445,9 +445,9 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $matrix[4].parameters.operatingSystem | Should -Be "macOS-10.15"
         $matrix[4].parameters.additionalArguments | Should -Be ""
 
-        $matrix[7].name | Should -Be "windows2019_net50_enableWindowsFoo"
+        $matrix[7].name | Should -Be "windows2022_net50_enableWindowsFoo"
         $matrix[7].parameters.framework | Should -Be "net50"
-        $matrix[7].parameters.operatingSystem | Should -Be "windows-2019"
+        $matrix[7].parameters.operatingSystem | Should -Be "windows-2022"
         $matrix[7].parameters.additionalArguments | Should -Be "--enableWindowsFoo"
     }
 
@@ -456,7 +456,7 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
 {
     "include": [
         {
-            "operatingSystem": "windows-2019",
+            "operatingSystem": "windows-2022",
             "framework": "net461"
         }
     ]
@@ -466,14 +466,14 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $config = GetMatrixConfigFromJson $matrixConfigForIncludeOnly
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 1
-        $matrix[0].name | Should -Be "windows2019_net461"
+        $matrix[0].name | Should -Be "windows2022_net461"
     }
 
     It "Should parse a config with an empty include" {
         $matrixConfigForIncludeOnly = @"
 {
     "matrix": {
-        "operatingSystem": "windows-2019",
+        "operatingSystem": "windows-2022",
         "framework": "net461"
     }
 }
@@ -482,7 +482,7 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $config = GetMatrixConfigFromJson $matrixConfigForIncludeOnly
         [Array]$matrix = GenerateMatrix $config "all"
         $matrix.Length | Should -Be 1
-        $matrix[0].name | Should -Be "windows2019_net461"
+        $matrix[0].name | Should -Be "windows2022_net461"
     }
 }
 

--- a/externals/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/externals/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -82,8 +82,8 @@ jobs:
         BuildType: Debug
 
       WindowsX86_Release_MapFiles_UnitTests:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=ON'
@@ -180,8 +180,8 @@ jobs:
         BuildType: Debug
 
       Windows_Preconditions_UnitTests_Samples:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=ON'
@@ -233,8 +233,8 @@ jobs:
         BuildType: Debug
 
       Windows_Release_Samples_MapFiles:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: windows-2022
         vcpkg.deps: 'paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF -DTRANSPORT_PAHO=ON'
@@ -434,8 +434,8 @@ jobs:
 
 - job: GenerateReleaseArtifacts
   pool:
-    name: azsdk-pool-mms-win-2019-general
-    vmImage: MMS2019
+    name: azsdk-pool-mms-win-2022-general
+    vmImage: windows-2022
   variables:
     Package.EnableSBOMSigning: true
   steps:

--- a/externals/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/externals/azure-sdk-for-c/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -16,8 +16,8 @@ jobs:
           test_type: 'iot'
           os: 'linux'
         Win_x64_with_iot_samples:
-          Pool: azsdk-pool-mms-win-2019-general
-          OSVmImage: MMS2019
+          Pool: azsdk-pool-mms-win-2022-general
+          OSVmImage: windows-2022
           vcpkg.deps: 'curl[winssl] cmocka paho-mqtt'
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
@@ -42,16 +42,16 @@ jobs:
         #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         #   build.args: ' -DTRANSPO.RT_CURL=ON -DAZ_PLATFORM_IMPL=POSIX'
         # Win_x86_with_sampldes:
-        #   Pool: azsdk-pool-mms-win-2019-general
-        #   OSVmImage: MMS2019
+        #   Pool: azsdk-pool-mms-win-2022-general
+        #   OSVmImage: windows-2022
         #   vcpkg.deps: 'curl[winssl]'
         #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
         #   CMAKE_GENERATOR_PLATFORM: Win32
         #   build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=WIN32'
         # Win_x64_with_samples:
-        #   Pool: azsdk-pool-mms-win-2019-general
-        #   OSVmImage: MMS2019
+        #   Pool: azsdk-pool-mms-win-2022-general
+        #   OSVmImage: windows-2022
         #   vcpkg.deps: 'curl[winssl]'
         #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         #   CMAKE_GENERATOR: 'Visual Studio 16 2019'

--- a/externals/azure-sdk-for-c/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/externals/azure-sdk-for-c/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -11,8 +11,8 @@ stages:
         environment: github
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:
@@ -37,15 +37,15 @@ stages:
                     RepoId: $(Build.Repository.Name)
                     WorkingDirectory: $(Build.SourcesDirectory)
                     ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
-                
+
       - deployment: PublishDocs
         displayName: Publish Docs to GitHub pages
         condition: ne(variables['Skip.PublishDocs'], 'true')
         environment: githubio
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:
@@ -70,8 +70,8 @@ stages:
         environment: github
 
         pool:
-          name: azsdk-pool-mms-win-2019-general
-          vmImage: MMS2019
+          name: azsdk-pool-mms-win-2022-general
+          vmImage: windows-2022
 
         strategy:
           runOnce:


### PR DESCRIPTION
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format.

This discussion explains why we chose given `vmImage` format:

[Mike Harder: 1ES Hosted Pool image name changes](https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1676491855184?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1676491855184&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1676491855184)
posted in Azure SDK / Engineering System 🛠️ at Wednesday, February 15, 2023 12:10 PM

## Changes made in the PR

- search-and-replace all occurrences of `windows-2019` and `windows2019` to corresponding `2022` variant
- search-and-replace `azsdk-pool-mms-win-2019-general` with `azsdk-pool-mms-win-2022-general`
- added `azsdk-pool-mms-win-2022-general` as pool name to `docindex.yml` files, as it was absent from there
- search and replace `MMS2019` and `MMS2022` to `windows-2022`

## Context

For further context, please see:
- https://github.com/Azure/azure-sdk-tools/issues/3407