### PR TITLE
RYZ014A/024A: ewf_adapter_stop always return with an error

### DIFF
--- a/src/ewf_adapter_renesas_common_control.c
+++ b/src/ewf_adapter_renesas_common_control.c
@@ -888,7 +888,7 @@ ewf_result ewf_adapter_renesas_common_stop(ewf_adapter* adapter_ptr)
     }
 
     /* Cleanup the interface */
-    if (ewf_result_failed(result = ewf_interface_init(interface_ptr)))
+    if (ewf_result_failed(result = ewf_interface_clean(interface_ptr)))
     {
         EWF_LOG_ERROR("Failed to clean the interface: ewf_result %d.\n", result);
         return EWF_RESULT_INTERFACE_INITIALIZATION_FAILED;

--- a/src/ewf_interface_ra_uart.c
+++ b/src/ewf_interface_ra_uart.c
@@ -77,7 +77,11 @@ ewf_result ewf_interface_ra_uart_hardware_start(ewf_interface* interface_ptr)
     g_interface_ptr = interface_ptr;
 
     /* Initialize UART channel */
+#if (BSP_FEATURE_SCI_VERSION == 2U)
+    status = R_SCI_B_UART_Open (&g_uart0_ctrl, &g_uart0_cfg);
+#else
     status = R_SCI_UART_Open (&g_uart0_ctrl, &g_uart0_cfg);
+#endif
     if (FSP_SUCCESS != status)
       return EWF_RESULT_INTERFACE_INITIALIZATION_FAILED;
 
@@ -94,7 +98,11 @@ ewf_result ewf_interface_ra_uart_hardware_stop(ewf_interface* interface_ptr)
 #endif
 
     /* Close module */
+#if (BSP_FEATURE_SCI_VERSION == 2U)
+    R_SCI_B_UART_Close (&g_uart0_ctrl);
+#else
     R_SCI_UART_Close (&g_uart0_ctrl);
+#endif
 
     return EWF_RESULT_OK;
 }
@@ -114,7 +122,11 @@ ewf_result ewf_interface_ra_uart_hardware_send(ewf_interface* interface_ptr, con
     g_uart_event = 0;
 
     /* Writing to terminal */
+#if (BSP_FEATURE_SCI_VERSION == 2U)
+    err = R_SCI_B_UART_Write (&g_uart0_ctrl, (uint8_t *) buffer, length);
+#else
     err = R_SCI_UART_Write (&g_uart0_ctrl, (uint8_t *) buffer, length);
+#endif
     if (FSP_SUCCESS != err)
     {
         return EWF_RESULT_ADAPTER_TRANSMIT_FAILED;

--- a/src/ewf_interface_ra_uart.c
+++ b/src/ewf_interface_ra_uart.c
@@ -77,11 +77,8 @@ ewf_result ewf_interface_ra_uart_hardware_start(ewf_interface* interface_ptr)
     g_interface_ptr = interface_ptr;
 
     /* Initialize UART channel */
-#if (BSP_FEATURE_SCI_VERSION == 2U)
-    status = R_SCI_B_UART_Open (&g_uart0_ctrl, &g_uart0_cfg);
-#else
-    status = R_SCI_UART_Open (&g_uart0_ctrl, &g_uart0_cfg);
-#endif
+    status = g_uart0.p_api->open(g_uart0.p_ctrl, g_uart0.p_cfg);
+
     if (FSP_SUCCESS != status)
       return EWF_RESULT_INTERFACE_INITIALIZATION_FAILED;
 
@@ -98,11 +95,7 @@ ewf_result ewf_interface_ra_uart_hardware_stop(ewf_interface* interface_ptr)
 #endif
 
     /* Close module */
-#if (BSP_FEATURE_SCI_VERSION == 2U)
-    R_SCI_B_UART_Close (&g_uart0_ctrl);
-#else
-    R_SCI_UART_Close (&g_uart0_ctrl);
-#endif
+    g_uart0.p_api->close(g_uart0.p_ctrl);
 
     return EWF_RESULT_OK;
 }
@@ -122,11 +115,8 @@ ewf_result ewf_interface_ra_uart_hardware_send(ewf_interface* interface_ptr, con
     g_uart_event = 0;
 
     /* Writing to terminal */
-#if (BSP_FEATURE_SCI_VERSION == 2U)
-    err = R_SCI_B_UART_Write (&g_uart0_ctrl, (uint8_t *) buffer, length);
-#else
-    err = R_SCI_UART_Write (&g_uart0_ctrl, (uint8_t *) buffer, length);
-#endif
+    g_uart0.p_api->write(g_uart0.p_ctrl, (uint8_t *) buffer, length);
+
     if (FSP_SUCCESS != err)
     {
         return EWF_RESULT_ADAPTER_TRANSMIT_FAILED;

--- a/src/ewf_interface_ra_uart.h
+++ b/src/ewf_interface_ra_uart.h
@@ -11,12 +11,6 @@
 
 #include "ewf_interface.h"
 
-#if (BSP_FEATURE_SCI_VERSION == 2U)
-    #include "r_sci_b_uart.h"
-#else
-    #include "r_sci_uart.h"
-#endif
-
 #include "r_uart_api.h"
 #include "hal_data.h"
 

--- a/src/ewf_interface_ra_uart.h
+++ b/src/ewf_interface_ra_uart.h
@@ -11,7 +11,12 @@
 
 #include "ewf_interface.h"
 
-#include "r_sci_uart.h"
+#if (BSP_FEATURE_SCI_VERSION == 2U)
+    #include "r_sci_b_uart.h"
+#else
+    #include "r_sci_uart.h"
+#endif
+
 #include "r_uart_api.h"
 #include "hal_data.h"
 


### PR DESCRIPTION
`ewf_adapter_renesas_common_stop` calls `ewf_interface_init` instead of `ewf_interface_clean` which causes multiple errors in the EWF stack:

![image](https://github.com/Azure/embedded-wireless-framework/assets/78607734/b24d6a99-0f92-4330-97e1-1838bf9d1bdb)
